### PR TITLE
feat(core): Register AngularFire and Angular versions with the JS SDK

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -307,6 +307,12 @@ function replaceDynamicImportsForUMD() {
   writeFileSync('./dist/packages-dist/remote-config/remote-config.d.ts', readFileSync('./dist/packages-dist/remote-config/remote-config.d.ts', 'utf8').replace("implements remoteConfig.Value", "implements Partial<remoteConfig.Value>"));
 }
 
+function writeCoreVersion() {
+  writeFileSync('./dist/packages-dist/bundles/core.umd.js', readFileSync('./dist/packages-dist/bundles/core.umd.js', 'utf8').replace('ANGULARFIRE2_VERSION', VERSIONS.ANGULARFIRE2_VERSION));
+  writeFileSync('./dist/packages-dist/firebase.app.module.js', readFileSync('./dist/packages-dist/firebase.app.module.js', 'utf8').replace('ANGULARFIRE2_VERSION', VERSIONS.ANGULARFIRE2_VERSION));
+  writeFileSync('./dist/packages-dist/es2015/firebase.app.module.js', readFileSync('./dist/packages-dist/es2015/firebase.app.module.js', 'utf8').replace('ANGULARFIRE2_VERSION', VERSIONS.ANGULARFIRE2_VERSION));
+}
+
 function measure(module) {
   const path = `${process.cwd()}/dist/packages-dist/bundles/${module}.umd.js`;
   const file = readFileSync(path);
@@ -408,6 +414,7 @@ function buildLibrary(globals) {
     switchMap(() => from(createTestUmd(globals))),
     tap(() => {
       replaceDynamicImportsForUMD();
+      writeCoreVersion();
       const coreStats = measure('core');
       const analyticsStats = measure('analytics');
       const authStats = measure('auth');


### PR DESCRIPTION
If the JS SDK has the `registerVersion` API, we should register the version of Angular and AngularFire.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

